### PR TITLE
Add compatibility with the Mac platform

### DIFF
--- a/watch_darwin.go
+++ b/watch_darwin.go
@@ -1,3 +1,4 @@
+// +build !linux, darwin
 package main
 
 import (
@@ -18,7 +19,7 @@ var watchExtensions = map[string]bool{
 
 func watch() {
 	c := make(chan notify.EventInfo, 1)
-	err := notify.Watch("./...", c, notify.InCloseWrite, notify.InMovedFrom, notify.InMovedTo, notify.Remove)
+	err := notify.Watch("./...", c, notify.Remove, notify.FSEventsMount, notify.FSEventsRenamed, notify.FSEventsRemoved)
 
 	if err != nil {
 		log.Fatal(err)

--- a/watch_linux.go
+++ b/watch_linux.go
@@ -1,0 +1,54 @@
+// +build linux,!darwin
+package main
+
+import (
+	"log"
+	"path/filepath"
+	"strings"
+
+	"github.com/rjeczalik/notify"
+)
+
+var watchExtensions = map[string]bool{
+	".go":      true,
+	".js":      true,
+	".pixy":    true,
+	".scarlet": true,
+	".json":    true,
+}
+
+func watch() {
+	c := make(chan notify.EventInfo, 1)
+	err := notify.Watch("./...", c, notify.InCloseWrite, notify.InMovedFrom, notify.InMovedTo, notify.Remove)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for fileEvent := range c {
+		// if server == nil {
+		// 	continue
+		// }
+
+		relPath, _ := filepath.Rel(cwd, fileEvent.Path())
+
+		// Ignore hidden files
+		if strings.HasPrefix(relPath, ".") {
+			continue
+		}
+
+		extension := filepath.Ext(relPath)
+
+		// Only care about certain extensions
+		_, ok := watchExtensions[extension]
+
+		if !ok {
+			continue
+		}
+
+		break
+	}
+
+	notify.Stop(c)
+	restart()
+}


### PR DESCRIPTION
# Recap
I've just duplicated the original **watch** file and changed the signals that were listened, so they are compatible with MacOs.

Another solution could have been to create two new files containing platform specifics events and reference those events when calling the `notify.Watch` function, but I wasn't sure if I could come up with a clean version for this option.

# Environment
I've tested it on MacOs High Siera version 10.13.2 on a MacBook Pro (Retina, 15-inch, Mid 2015). 
I used it when developing the recent new quote feature on [notify.moe](https://github.com/animenotifier/notify.moe/issues/21) and it appeared to be working as expected.

**⚠️ Be aware that I couldn't prove that it's functional and without regression on a Linux distribution due a lack of available space to create a VM.**