### PR TITLE
Fix installation instructions for "pack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Runs an [Aero](https://github.com/aerogo/aero) project and restarts on code/temp
 [pack](https://github.com/aerogo/pack) needs to be installed:
 
 ```shell
-go get -u github.com/aerogo/pack
+go get -u github.com/aerogo/pack/...
 ```
 
 ## Installation

--- a/README.src.md
+++ b/README.src.md
@@ -11,7 +11,7 @@ Runs an [Aero](https://github.com/aerogo/aero) project and restarts on code/temp
 [pack](https://github.com/aerogo/pack) needs to be installed:
 
 ```shell
-go get -u github.com/aerogo/pack
+go get -u github.com/aerogo/pack/...
 ```
 
 {go:install}


### PR DESCRIPTION
The current instructions are likely outdated and as such cause errors. This small fix should improve accessibility for new go devs trying to run this package.